### PR TITLE
Hide client ID and Secret using cocoapods-keys

### DIFF
--- a/Exhibit.xcodeproj/project.pbxproj
+++ b/Exhibit.xcodeproj/project.pbxproj
@@ -526,6 +526,7 @@
 				457C07351B1E12750035F784 /* Frameworks */,
 				457C07361B1E12750035F784 /* Resources */,
 				4BCB07A19A598430B30B046D /* Copy Pods Resources */,
+				11854124639A0A611CA4194F /* Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -565,7 +566,7 @@
 				TargetAttributes = {
 					457C07371B1E12750035F784 = {
 						CreatedOnToolsVersion = 6.3.2;
-						DevelopmentTeam = WD972BHRT7;
+						DevelopmentTeam = 4Q596JWQC5;
 					};
 					457C07501B1E12760035F784 = {
 						CreatedOnToolsVersion = 6.3.2;
@@ -632,6 +633,21 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		11854124639A0A611CA4194F /* Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		4BCB07A19A598430B30B046D /* Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Exhibit/AppDelegate.m
+++ b/Exhibit/AppDelegate.m
@@ -18,9 +18,7 @@
 #import "RootViewController.h"
 #import "StorageClient.h"
 #import "LogoViewController.h"
-
-static NSString *const AubergisteClientID = @"893123332c62670ee75b90df3e6378d2cefc85ac84d3e07d63ae37291414bef0";
-static NSString *const AubergisteClientSecret = @"1e443d57507880fe32853ddf242e13762e17843300e87f3ce25eb8c6e434cb61";
+#import <Keys/ExhibitKeys.h>
 
 @interface AppDelegate () <RootViewControllerDelegate>
 @property (nonatomic) SlideshowController *slideshowController;
@@ -34,7 +32,10 @@ static NSString *const AubergisteClientSecret = @"1e443d57507880fe32853ddf242e13
 
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    [[AUBAubergiste sharedInstance] setClientID:AubergisteClientID clientSecret:AubergisteClientSecret];
+    
+    ExhibitKeys *keys = [[ExhibitKeys alloc] init];
+    
+    [[AUBAubergiste sharedInstance] setClientID:keys.aubergisteClientID clientSecret:keys.aubergisteClientSecret];
     
     [application setStatusBarHidden:YES];
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+# A sample Gemfile
+source "https://rubygems.org"
+
+gem 'cocoapods', '~> 0.39.0'
+gem 'cocoapods-keys', '~> 1.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,73 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    RubyInline (3.12.4)
+      ZenTest (~> 4.3)
+    ZenTest (4.11.0)
+    activesupport (4.2.5)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (0.9.1)
+    cocoapods (0.39.0)
+      activesupport (>= 4.0.2)
+      claide (~> 0.9.1)
+      cocoapods-core (= 0.39.0)
+      cocoapods-downloader (~> 0.9.3)
+      cocoapods-plugins (~> 0.4.2)
+      cocoapods-search (~> 0.1.0)
+      cocoapods-stats (~> 0.6.2)
+      cocoapods-trunk (~> 0.6.4)
+      cocoapods-try (~> 0.5.1)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      molinillo (~> 0.4.0)
+      nap (~> 1.0)
+      xcodeproj (~> 0.28.2)
+    cocoapods-core (0.39.0)
+      activesupport (>= 4.0.2)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 1.0)
+    cocoapods-downloader (0.9.3)
+    cocoapods-keys (1.6.0)
+      dotenv
+      osx_keychain
+    cocoapods-plugins (0.4.2)
+      nap
+    cocoapods-search (0.1.0)
+    cocoapods-stats (0.6.2)
+    cocoapods-trunk (0.6.4)
+      nap (>= 0.8, < 2.0)
+      netrc (= 0.7.8)
+    cocoapods-try (0.5.1)
+    colored (1.2)
+    dotenv (2.0.2)
+    escape (0.0.4)
+    fuzzy_match (2.0.4)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.3)
+    molinillo (0.4.0)
+    nap (1.0.0)
+    netrc (0.7.8)
+    osx_keychain (1.0.1)
+      RubyInline (~> 3)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcodeproj (0.28.2)
+      activesupport (>= 3)
+      claide (~> 0.9.1)
+      colored (~> 1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods (~> 0.39.0)
+  cocoapods-keys (~> 1.6)
+
+BUNDLED WITH
+   1.10.6

--- a/Podfile
+++ b/Podfile
@@ -17,3 +17,10 @@ pod 'pop', '~> 1.0'
 pod 'SDWebImage'
 pod 'FormatterKit'
 pod 'TTTAttributedLabel'
+
+plugin 'cocoapods-keys', {
+  :project => "Exhibit",
+  :keys => [
+    "AubergisteClientID",
+    "AubergisteClientSecret"
+  ]}

--- a/Podfile
+++ b/Podfile
@@ -24,3 +24,4 @@ plugin 'cocoapods-keys', {
     "AubergisteClientID",
     "AubergisteClientSecret"
   ]}
+

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,6 +23,7 @@ PODS:
   - GPUImage (0.1.6)
   - ISO8601DateFormatter (0.7)
   - JNWSpringAnimation (0.7.1)
+  - Keys (1.0.0)
   - MCCollectionTypeSafety (0.1.2)
   - MCUIColorUtils (1.0.0)
   - MCUIImageAdvanced (0.2.7):
@@ -41,6 +42,7 @@ DEPENDENCIES:
   - FormatterKit
   - GPUImage
   - JNWSpringAnimation
+  - Keys (from `Pods/CocoaPodsKeys`)
   - MCCollectionTypeSafety (from `https://github.com/mirego/MCCollectionTypeSafety.git`)
   - MCUIColorUtils (~> 1.0.0)
   - MCUIImageAdvanced (~> 0.2.5)
@@ -53,6 +55,8 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   Aubergiste:
     :git: git@github.com:mirego/Aubergiste.git
+  Keys:
+    :path: Pods/CocoaPodsKeys
   MCCollectionTypeSafety:
     :git: https://github.com/mirego/MCCollectionTypeSafety.git
   MRGArchitect:
@@ -76,6 +80,7 @@ SPEC CHECKSUMS:
   GPUImage: 4675ce4a5370ca92fcea8623b2a08b8f0c51b940
   ISO8601DateFormatter: ab926648eebe497f4d167c0fd083992f959f1274
   JNWSpringAnimation: cd4c2f4464324f63f176c3624ffccf205211a100
+  Keys: 7d2ff6ff42f6903358267ce56e9392f83c31acfe
   MCCollectionTypeSafety: 6907ffb1d98f75e3bf5a72f52e32e75bef73b3d4
   MCUIColorUtils: 6f11e1702db4ff5419d28cba1e8f7a82dd82d5fe
   MCUIImageAdvanced: fbc5873532933a17317fa02b45daf715565b8608
@@ -86,4 +91,4 @@ SPEC CHECKSUMS:
   SDWebImage: 71b7cdc1d1721d6a82ed62889030225f2c249e29
   TTTAttributedLabel: 0a2ac7b2dd726d32a070dafb01446026b11e624f
 
-COCOAPODS: 0.37.2
+COCOAPODS: 0.39.0


### PR DESCRIPTION
Uses [cocoapods-keys](https://github.com/orta/cocoapods-keys) to obfuscate the client id and secret. The keys will be asked during next pod install. :boom: 
